### PR TITLE
Add create command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clasp Action
 
-This action uses [clasp](https://github.com/google/clasp) to push or deploy to [Google Apps Script](https://developers.google.com/apps-script/). This action is running `clasp push -f` regardless of whether you select `push` or `deploy` as the command. This will force the remote manifest to be overwritten.
+This action uses [clasp](https://github.com/google/clasp) to push, deploy or create projects on [Google Apps Script](https://developers.google.com/apps-script/). This action is running `clasp push -f` regardless of whether you select `push` or `deploy` as the command. This will force the remote manifest to be overwritten.
 
 ## Inputs
 
@@ -34,7 +34,7 @@ Directory where scripts are stored.
 
 ### `command`
 
-**Required** Command to execute(`push` or `deploy`).
+**Required** Command to execute(`push`, `deploy` or `create`).
 
 If `deploy` is selected, this action is running `clasp push -f` just before.
 
@@ -48,6 +48,10 @@ Description of the deployment.
 ### `deployId`
 
 Deploy ID that will be updated with this push.
+
+### `title`
+
+Title of the script. Required when `command` is `create`.
 
 ## Example usage
 
@@ -122,6 +126,21 @@ Deploy ID that will be updated with this push.
     scriptId: ${{ secrets.SCRIPT_ID }}
     command: 'deploy'
     deployId: ${{ secrets.DEPLOY_ID }}
+```
+
+### Case to create a new script
+
+```yaml
+- uses: daikikatsuragawa/clasp-action@v1.1.0
+  with:
+    accessToken: ${{ secrets.ACCESS_TOKEN }}
+    idToken: ${{ secrets.ID_TOKEN }}
+    refreshToken: ${{ secrets.REFRESH_TOKEN }}
+    clientId: ${{ secrets.CLIENT_ID }}
+    clientSecret: ${{ secrets.CLIENT_SECRET }}
+    command: 'create'
+    title: 'My Spreadsheet Script'
+    rootDir: 'src'
 ```
 
 ## License summary

--- a/action.yml
+++ b/action.yml
@@ -26,13 +26,16 @@ inputs:
     description: 'Directory where scripts are stored'
     required: false
   command:
-    description: 'Command to execute(push or deploy)'
+    description: 'Command to execute(push, deploy or create)'
     required: true
   description:
     description: 'Description of the deployment'
     required: false
   deployId:
     description: 'Deploy ID that will be updated'
+    required: false
+  title:
+    description: 'Title of the script (required for create command)'
     required: false
 runs:
   using: 'docker'
@@ -48,3 +51,4 @@ runs:
     - ${{ inputs.command }}
     - ${{ inputs.description }}
     - ${{ inputs.deployId }}
+    - ${{ inputs.title }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,27 +21,32 @@ END
 
 echo $CLASPRC > ~/.clasprc.json
 
-CLASP=$(cat <<-END
+COMMAND="$8"
+TITLE="${11}"
+
+if [ "$COMMAND" = "push" ] || [ "$COMMAND" = "deploy" ]; then
+  CLASP=$(cat <<-END
     {
         "scriptId": "$6"
     }
 END
-)
+  )
 
-if [ -n "$7" ]; then
-  if [ -e "$7" ]; then
-    cd "$7"
-  else
-    echo "rootDir is invalid."
-    exit 1
+  if [ -n "$7" ]; then
+    if [ -e "$7" ]; then
+      cd "$7"
+    else
+      echo "rootDir is invalid."
+      exit 1
+    fi
   fi
+
+  echo $CLASP > .clasp.json
 fi
 
-echo $CLASP > .clasp.json
-
-if [ "$8" = "push" ]; then
+if [ "$COMMAND" = "push" ]; then
   clasp push -f
-elif [ "$8" = "deploy" ]; then
+elif [ "$COMMAND" = "deploy" ]; then
   if [ -n "$9" ]; then
     clasp push -f
 
@@ -58,6 +63,17 @@ elif [ "$8" = "deploy" ]; then
     else
       clasp deploy
     fi
+  fi
+elif [ "$COMMAND" = "create" ]; then
+  if [ -z "$TITLE" ]; then
+    echo "title is required for create command."
+    exit 1
+  fi
+
+  if [ -n "$7" ]; then
+    clasp create-script --type sheets --title "$TITLE" --rootDir "$7"
+  else
+    clasp create-script --type sheets --title "$TITLE"
   fi
 else
   echo "command is invalid."


### PR DESCRIPTION
## Summary
- allow 'create' as a new command
- document `title` input and example usage

## Testing
- `bash -n entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843225e1d3483309660c5da9585f2e8