### PR TITLE
Add outputs for created URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ Deploy ID that will be updated with this push.
 
 Title of the script. Required when `command` is `create`.
 
+## Outputs
+
+### `script_url`
+
+URL of the created script when `command` is `create`.
+
+### `spreadsheet_url`
+
+URL of the newly created spreadsheet document when `command` is `create`.
+
 ## Example usage
 
 ### Case to push

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,11 @@ inputs:
   title:
     description: 'Title of the script (required for create command)'
     required: false
+outputs:
+  script_url:
+    description: 'URL of the created script when using the create command'
+  spreadsheet_url:
+    description: 'URL of the newly created spreadsheet document when using the create command'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,9 +71,18 @@ elif [ "$COMMAND" = "create" ]; then
   fi
 
   if [ -n "$7" ]; then
-    clasp create-script --type sheets --title "$TITLE" --rootDir "$7"
+    CREATE_OUT=$(clasp create-script --type sheets --title "$TITLE" --rootDir "$7" 2>&1)
   else
-    clasp create-script --type sheets --title "$TITLE"
+    CREATE_OUT=$(clasp create-script --type sheets --title "$TITLE" 2>&1)
+  fi
+  echo "$CREATE_OUT"
+  SPREADSHEET_URL=$(echo "$CREATE_OUT" | grep -o 'https://drive.google.com[^ ]*')
+  SCRIPT_URL=$(echo "$CREATE_OUT" | grep -o 'https://script.google.com[^ ]*')
+  if [ -n "$SPREADSHEET_URL" ]; then
+    echo "spreadsheet_url=$SPREADSHEET_URL" >> "$GITHUB_OUTPUT"
+  fi
+  if [ -n "$SCRIPT_URL" ]; then
+    echo "script_url=$SCRIPT_URL" >> "$GITHUB_OUTPUT"
   fi
 else
   echo "command is invalid."


### PR DESCRIPTION
## Summary
- document `script_url` and `spreadsheet_url` outputs
- define new outputs in `action.yml`
- expose both URLs from the create command

## Testing
- `sh -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_6843381335148330a68042c11bdd8b1f