### PR TITLE
Add create_and_push command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clasp Action
 
-This action uses [clasp](https://github.com/google/clasp) to push, deploy or create projects on [Google Apps Script](https://developers.google.com/apps-script/). This action is running `clasp push -f` regardless of whether you select `push` or `deploy` as the command. This will force the remote manifest to be overwritten.
+This action uses [clasp](https://github.com/google/clasp) to push, deploy, create or create and push projects on [Google Apps Script](https://developers.google.com/apps-script/). This action is running `clasp push -f` regardless of whether you select `push` or `deploy` as the command. This will force the remote manifest to be overwritten.
 
 ## Inputs
 
@@ -34,7 +34,7 @@ Directory where scripts are stored.
 
 ### `command`
 
-**Required** Command to execute(`push`, `deploy` or `create`).
+**Required** Command to execute(`push`, `deploy`, `create` or `create_and_push`).
 
 If `deploy` is selected, this action is running `clasp push -f` just before.
 
@@ -51,17 +51,17 @@ Deploy ID that will be updated with this push.
 
 ### `title`
 
-Title of the script. Required when `command` is `create`.
+Title of the script. Required when `command` is `create` or `create_and_push`.
 
 ## Outputs
 
 ### `script_url`
 
-URL of the created script when `command` is `create`.
+URL of the created script when `command` is `create` or `create_and_push`.
 
 ### `spreadsheet_url`
 
-URL of the newly created spreadsheet document when `command` is `create`.
+URL of the newly created spreadsheet document when `command` is `create` or `create_and_push`.
 
 ## Example usage
 
@@ -149,6 +149,21 @@ URL of the newly created spreadsheet document when `command` is `create`.
     clientId: ${{ secrets.CLIENT_ID }}
     clientSecret: ${{ secrets.CLIENT_SECRET }}
     command: 'create'
+    title: 'My Spreadsheet Script'
+    rootDir: 'src'
+```
+
+### Case to create a new script and push
+
+```yaml
+- uses: daikikatsuragawa/clasp-action@v1.1.0
+  with:
+    accessToken: ${{ secrets.ACCESS_TOKEN }}
+    idToken: ${{ secrets.ID_TOKEN }}
+    refreshToken: ${{ secrets.REFRESH_TOKEN }}
+    clientId: ${{ secrets.CLIENT_ID }}
+    clientSecret: ${{ secrets.CLIENT_SECRET }}
+    command: 'create_and_push'
     title: 'My Spreadsheet Script'
     rootDir: 'src'
 ```

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: 'Directory where scripts are stored'
     required: false
   command:
-    description: 'Command to execute(push, deploy or create)'
+    description: 'Command to execute(push, deploy, create or create_and_push)'
     required: true
   description:
     description: 'Description of the deployment'
@@ -35,13 +35,13 @@ inputs:
     description: 'Deploy ID that will be updated'
     required: false
   title:
-    description: 'Title of the script (required for create command)'
+    description: 'Title of the script (required for create or create_and_push command)'
     required: false
 outputs:
   script_url:
-    description: 'URL of the created script when using the create command'
+    description: 'URL of the created script when using the create or create_and_push command'
   spreadsheet_url:
-    description: 'URL of the newly created spreadsheet document when using the create command'
+    description: 'URL of the newly created spreadsheet document when using the create or create_and_push command'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,6 +84,28 @@ elif [ "$COMMAND" = "create" ]; then
   if [ -n "$SCRIPT_URL" ]; then
     echo "script_url=$SCRIPT_URL" >> "$GITHUB_OUTPUT"
   fi
+elif [ "$COMMAND" = "create_and_push" ]; then
+  if [ -z "$TITLE" ]; then
+    echo "title is required for create_and_push command."
+    exit 1
+  fi
+
+  if [ -n "$7" ]; then
+    CREATE_OUT=$(clasp create-script --type sheets --title "$TITLE" --rootDir "$7" 2>&1)
+    cd "$7"
+  else
+    CREATE_OUT=$(clasp create-script --type sheets --title "$TITLE" 2>&1)
+  fi
+  echo "$CREATE_OUT"
+  SPREADSHEET_URL=$(echo "$CREATE_OUT" | grep -o 'https://drive.google.com[^ ]*')
+  SCRIPT_URL=$(echo "$CREATE_OUT" | grep -o 'https://script.google.com[^ ]*')
+  if [ -n "$SPREADSHEET_URL" ]; then
+    echo "spreadsheet_url=$SPREADSHEET_URL" >> "$GITHUB_OUTPUT"
+  fi
+  if [ -n "$SCRIPT_URL" ]; then
+    echo "script_url=$SCRIPT_URL" >> "$GITHUB_OUTPUT"
+  fi
+  clasp push -f
 else
   echo "command is invalid."
   exit 1


### PR DESCRIPTION
## Summary
- add a `create_and_push` command
- document the new command in README and update usage examples
- describe new command in action.yml
- fix root directory handling for `create_and_push`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684340e2f99c83309062d2869e85846c