### PR TITLE
Add projectId input

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This action uses [clasp](https://github.com/google/clasp) to push, deploy, creat
 
 **Required** `scriptId` written in `.clasp.json`.
 
+### `projectId`
+
+`projectId` written in `.clasp.json`.
+
 ### `rootDir`
 
 Directory where scripts are stored.
@@ -76,6 +80,7 @@ URL of the newly created spreadsheet document when `command` is `create` or `cre
     clientId: ${{ secrets.CLIENT_ID }}
     clientSecret: ${{ secrets.CLIENT_SECRET }}
     scriptId: ${{ secrets.SCRIPT_ID }}
+    projectId: ${{ secrets.PROJECT_ID }}
     command: 'push'
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   scriptId:
     description: 'scriptId written in .clasp.json'
     required: true
+  projectId:
+    description: 'projectId written in .clasp.json'
+    required: false
   rootDir:
     description: 'Directory where scripts are stored'
     required: false
@@ -52,6 +55,7 @@ runs:
     - ${{ inputs.clientId }}
     - ${{ inputs.clientSecret }}
     - ${{ inputs.scriptId }}
+    - ${{ inputs.projectId }}
     - ${{ inputs.rootDir }}
     - ${{ inputs.command }}
     - ${{ inputs.description }}


### PR DESCRIPTION
## Summary
- add optional `projectId` input
- set projectId in `.clasp.json`
- document projectId usage
- remove deprecated `clasp setting` calls

## Testing
- `bash -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_6849b9dcfa8083308709deedd2cc8955