### PR TITLE
Add email/password support and API trigger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN apk add --update npm
+RUN apk add --update npm curl jq
 
 RUN npm install -g @google/clasp
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ Deploy ID that will be updated with this push.
 
 Title of the script. Required when `command` is `create` or `create_and_push`.
 
+### `email`
+
+Email used for API authentication when using the `create_and_push` command.
+
+### `password`
+
+Password used for API authentication when using the `create_and_push` command.
+
 ## Outputs
 
 ### `script_url`
@@ -171,6 +179,8 @@ URL of the newly created spreadsheet document when `command` is `create` or `cre
     command: 'create_and_push'
     title: 'My Spreadsheet Script'
     rootDir: 'src'
+    email: ${{ secrets.EMAIL }}
+    password: ${{ secrets.PASSWORD }}
 ```
 
 ## License summary

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,12 @@ inputs:
   title:
     description: 'Title of the script (required for create or create_and_push command)'
     required: false
+  email:
+    description: 'Email used for API authentication'
+    required: false
+  password:
+    description: 'Password used for API authentication'
+    required: false
 outputs:
   script_url:
     description: 'URL of the created script when using the create or create_and_push command'
@@ -61,3 +67,5 @@ runs:
     - ${{ inputs.description }}
     - ${{ inputs.deployId }}
     - ${{ inputs.title }}
+    - ${{ inputs.email }}
+    - ${{ inputs.password }}


### PR DESCRIPTION
## Summary
- support new `email` and `password` inputs
- install jq and curl in the container
- trigger API before pushing in `create_and_push` command
- document new inputs in README

## Testing
- `bash -n entrypoint.sh`
- `shellcheck entrypoint.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cacb6848833084fed894b6f45536