### PR TITLE
Fix spreadsheet ID extraction in delete command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -191,9 +191,9 @@ elif [ "$COMMAND" = "delete" ]; then
     exit 0
   fi
 
-  SPREADSHEET_ID=$(echo "$SPREADSHEET_URL" | sed -E 's#.*/d/([^/?]+).*#\1#')
+  SPREADSHEET_ID=$(echo "$SPREADSHEET_URL" | sed -nE 's#.*/d/([^/?]+).*#\1#p')
   if [ -z "$SPREADSHEET_ID" ]; then
-    SPREADSHEET_ID=$(echo "$SPREADSHEET_URL" | sed -E 's#.*id=([^&]+).*#\1#')
+    SPREADSHEET_ID=$(echo "$SPREADSHEET_URL" | sed -nE 's#.*id=([^&]+).*#\1#p')
   fi
 
   if [ -z "$SPREADSHEET_ID" ]; then


### PR DESCRIPTION
## Summary
- ensure delete command extracts spreadsheet ID correctly

## Testing
- `bash -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_684d8ab7b0f8833094d935f3d2875704