### PR TITLE
Add versioning and test automation to create_and_push

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN apk add --update npm curl jq
+RUN apk add --update npm curl jq python3
 
 RUN npm install -g @google/clasp
 


### PR DESCRIPTION
## Summary
- install python to support combining files
- enhance `create_and_push` command to copy test manifest, create a version and deployment, and run tests if new ones are added

## Testing
- `bash -n entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d9e6c48dc833084b44b6b5e2ad6b6