### PR TITLE
Fix create_and_push manifest overwrite

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,10 +97,23 @@ elif [ "$COMMAND" = "create_and_push" ]; then
   fi
 
   if [ -n "$8" ]; then
+    MANIFEST_PATH="$8/appsscript.json"
+    if [ -f "$MANIFEST_PATH" ]; then
+      cp "$MANIFEST_PATH" "$MANIFEST_PATH.bak"
+    fi
     CREATE_OUT=$(clasp create-script --type sheets --title "$TITLE" --rootDir "$8" 2>&1)
+    if [ -f "$MANIFEST_PATH.bak" ]; then
+      mv "$MANIFEST_PATH.bak" "$MANIFEST_PATH"
+    fi
     cd "$8"
   else
+    if [ -f appsscript.json ]; then
+      cp appsscript.json appsscript.json.bak
+    fi
     CREATE_OUT=$(clasp create-script --type sheets --title "$TITLE" 2>&1)
+    if [ -f appsscript.json.bak ]; then
+      mv appsscript.json.bak appsscript.json
+    fi
   fi
   echo "$CREATE_OUT"
   if [ -n "$PROJECT_ID" ]; then


### PR DESCRIPTION
## Summary
- preserve existing `appsscript.json` when running the `create_and_push` command

## Testing
- `shellcheck entrypoint.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db9ec6dcc8330b0735fb9f613c78f