### PR TITLE
Fix git safe directory error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN apk add --update npm curl jq python3
+RUN apk add --update git npm curl jq python3
 
 RUN npm install -g @google/clasp
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,12 @@ END
 
 echo $CLASPRC > ~/.clasprc.json
 
+# Git may refuse to operate on repos owned by different users. Mark the
+# GitHub workspace as safe to avoid "dubious ownership" errors when the action
+# performs git commands.
+GIT_WORKSPACE="${GITHUB_WORKSPACE:-/github/workspace}"
+git config --global --add safe.directory "$GIT_WORKSPACE"
+
 COMMAND="$9"
 TITLE="${12}"
 PROJECT_ID="$7"


### PR DESCRIPTION
## Summary
- mark the GitHub workspace as a safe git directory to avoid dubious ownership errors

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684dbfa3515c8330a44bff2ffe4b8a31