### PR TITLE
Add test_output output variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ URL of the created script when `command` is `create` or `create_and_push`.
 
 URL of the newly created spreadsheet document when `command` is `create` or `create_and_push`.
 
+### `test_output`
+
+Result from the test function executed during `create_and_push`.
+
 ## Example usage
 
 ### Case to push

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,8 @@ outputs:
     description: 'URL of the created script when using the create or create_and_push command'
   spreadsheet_url:
     description: 'URL of the newly created spreadsheet document when using the create or create_and_push command'
+  test_output:
+    description: 'Result from the test function executed during create_and_push'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -213,6 +213,7 @@ EOF
     clasp run-function setupTestContext --params "[\"${SPREADSHEET_ID}\",\"Sheet1\"]"
     TEST_OUTPUT=$(clasp run-function "$TEST_FUNC" 2>&1)
     echo "$TEST_OUTPUT"
+    printf 'test_output<<EOF\n%s\nEOF\n' "$TEST_OUTPUT" >> "$GITHUB_OUTPUT"
     PR_NUMBER=$(jq -r '.pull_request.number // empty' "$GITHUB_EVENT_PATH")
     REPO_NAME=$(jq -r '.repository.full_name' "$GITHUB_EVENT_PATH")
     if [ -n "$PR_NUMBER" ] && [ -n "$GITHUB_TOKEN" ]; then


### PR DESCRIPTION
## Summary
- capture test output in `entrypoint.sh`
- expose new `test_output` output in `action.yml`
- document `test_output` in README

## Testing
- `shellcheck entrypoint.sh` *(fails: command not found)*
- `bash -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_684ef91c88488330833d7da12171903e